### PR TITLE
[AIX-1183] Replace annotation plugin with functional one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/fiftyone_labelbox"]
+	path = plugins/fiftyone_labelbox
+	url = https://github.com/SafelyYou-Inc/fiftyone_labelbox.git

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ target:
 	mkdir -p target
 
 annotation: target
-	pushd plugins/annotation && zip ../../target/safelyyou-annotation.zip -r . && popd
+	pushd plugins/fiftyone_labelbox && zip ../../target/safelyyou-fiftyone_labelbox.zip -r . && popd
 
 clean:
 	rm target/*

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ target:
 	mkdir -p target
 
 annotation: target
-	pushd plugins/fiftyone_labelbox && zip ../../target/safelyyou-fiftyone_labelbox.zip -r . && popd
+	pushd plugins/fiftyone_labelbox && zip ../../target/ehofesmann-fiftyone_labelbox.zip -r . && popd
 
 clean:
 	rm target/*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 target:
 	mkdir -p target
 


### PR DESCRIPTION
This PR replaces the annotation plugin with our forked version of Voxel51's standalone Labelbox plugin. The fork incorporates some additional changes that were required to make video annotation (and any annotation in general) possible in our setup (details available [here](https://github.com/ehofesmann/fiftyone_labelbox/pull/1)).

The new plugin is currently deployed to dev as `@ehofesmann/labelbox`. Here are some datasets that were annotated with it:
* [Image dataset](https://voxel51.ml.safely-you.cloud/datasets/rszeto-dev-lb-plugin-image/samples)
* [Video dataset](https://voxel51.ml.safely-you.cloud/datasets/rszeto-dev-lb-plugin-video/samples)
* [Grouped dataset (w/ thumbnail and video annotations)](https://voxel51.ml.safely-you.cloud/datasets/rszeto-dev-lb-plugin-groups/samples)